### PR TITLE
Remove unused FormData import

### DIFF
--- a/api/fashn-tryon.ts
+++ b/api/fashn-tryon.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import formidable from 'formidable';
 import fs from 'fs';
-import { FormData, Blob } from 'formdata-node';
+import { Blob } from 'formdata-node';
 
 export const config = { api: { bodyParser: false } };
 


### PR DESCRIPTION
## Summary
- clean api handler imports by removing unused `FormData`

## Testing
- `tsc --noEmit -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878a7f0b5108329bd0b7e517e9285cb